### PR TITLE
change _plot_args to correctly pop first argument

### DIFF
--- a/gr/pygr/mlab.py
+++ b/gr/pygr/mlab.py
@@ -4658,10 +4658,9 @@ def _plot_args(args, fmt='xys'):
         if x is None or column > 0:
             if column == 0:
                 a = np.array(args[0])
-
+                args.pop(0)
             if len(a.shape) == 2 and a.shape[0] == 2:
                 x, y = a[0, :], a[1, :]
-                args.pop(0)
             else:
                 if fmt == 'xys':
                     if len(a.shape) == 2:


### PR DESCRIPTION
Apologies for the duplicate PR, I forgot to create a new branch.

When attempting to plot using for example scatter3(x,y,z,c) the arguments are processed wrong and results in _plt.args being incorrectly set to [(x,x,y,z,''),(c,c,None,None,'')] instead of [(x,y,z,c,'')]. This results in the example code for scatter3 not actually working, and crashing the program.

I suspect this is due to the position of args.pop(0) on line 4664, meaning we don't always pop the first argument off. Please see the attached code which fixes this issue.

I still need to test this does not cause any regressions in other plots but it does indeed fix any 3d plots like scatter3.
